### PR TITLE
Add avirt

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "app-controller-submodule"]
 	path = app-controller-submodule
 	url = https://gerrit.automotivelinux.org/gerrit/apps/app-controller-submodule
+[submodule "libavirt"]
+	path = libavirt
+	url = https://git.automotivelinux.org/src/libavirt

--- a/conf.d/project/etc/smixer-4a-avirt.json
+++ b/conf.d/project/etc/smixer-4a-avirt.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "http://iot.bzh/download/public/schema/json/ctl-schema.json",
+    "metadata": {
+        "uid": "Soft Mixer",
+        "version": "1.0",
+        "api": "smixer",
+        "info": "Soft Mixer emulating hardware mixer"
+    },
+    "resources": [
+        {
+            "uid": "softmixer-avirt",
+            "info": "Map avirt-loop to 4A HAL streams",
+            "spath": "./package/lib/plugins:./package/var:./lib/plugins:./var:/usr/libexec/agl/smixer",
+            "libs": ["alsa-softmixer.ctlso"]
+        }
+    ],
+    "onload": [
+        {
+            "uid": "mixer-create-api",
+            "info": "Create Audio Router",
+            "action": "plugin://softmixer-avirt#MixerCreate",
+            "args": {
+                "uid":"Alsa-Mixer",
+                "max_loop": 1,
+                "max_sink": 16,
+                "max_source": 16,
+                "max_zone": 16,
+                "max_stream": 16,
+                "max_ramp": 6
+            }
+        },
+        {
+          "uid": "mixer-attach-loop",
+          "info": "Create Audio Router",
+          "action": "plugin://softmixer-avirt#MixerAttach",
+          "args": {
+              "loops" : {
+                  "uid":"AVIRT-Loopback",
+                  "path": "/dev/snd/by-path/platform-snd_avirt.0"
+              }
+          }
+        }
+    ]
+}

--- a/plugins/alsa/CMakeLists.txt
+++ b/plugins/alsa/CMakeLists.txt
@@ -34,8 +34,11 @@ PROJECT_TARGET_ADD(alsa-softmixer)
 
 	# Library dependencies (include updates automatically)
 	TARGET_LINK_LIBRARIES(${TARGET_NAME}
+		avirt
 		${link_libraries}
 	)
+
+	add_definitions(-DCONFIG_AVIRT)
 
 	target_include_directories(${TARGET_NAME}
 	PRIVATE "${CMAKE_SOURCE_DIR}/app-controller-submodule/ctl-lib"

--- a/plugins/alsa/alsa-api-loop.c
+++ b/plugins/alsa/alsa-api-loop.c
@@ -19,7 +19,49 @@
 #define _GNU_SOURCE  // needed for vasprintf
 
 #include "alsa-softmixer.h"
+#include <avirt/avirt.h>
 #include <string.h>
+
+#define UID_AVIRT_LOOP "AVIRT-Loopback"
+
+#define REGNUMID_0  51
+#define REGNUMID_1  57
+#define REGNUMID_2  63
+#define REGNUMID_3  69
+#define REGNUMID_4  75
+#define REGNUMID_5  81
+#define REGNUMID_6  87
+#define REGNUMID_7  93
+#define REGNUMID_8  99
+#define REGNUMID_9  105
+#define REGNUMID_10 111
+#define REGNUMID_11 117
+#define REGNUMID_12 123
+#define REGNUMID_13 129
+#define REGNUMID_14 135
+#define REGNUMID_15 141
+
+struct RegistryNumidMap {
+    int index;
+    int numid;
+} numidmap[] = {
+    { 0,  REGNUMID_0  },
+    { 1,  REGNUMID_1  },
+    { 2,  REGNUMID_2  },
+    { 3,  REGNUMID_3  },
+    { 4,  REGNUMID_4  },
+    { 5,  REGNUMID_5  },
+    { 6,  REGNUMID_6  },
+    { 7,  REGNUMID_7  },
+    { 8,  REGNUMID_8  },
+    { 9,  REGNUMID_9  },
+    { 10, REGNUMID_10 },
+    { 11, REGNUMID_11 },
+    { 12, REGNUMID_12 },
+    { 13, REGNUMID_13 },
+    { 14, REGNUMID_14 },
+    { 15, REGNUMID_15 },
+};
 
 PUBLIC AlsaLoopSubdevT *ApiLoopFindSubdev(SoftMixerT *mixer, const char *streamUid, const char *targetUid, AlsaSndLoopT **loop) {
 
@@ -47,6 +89,47 @@ PUBLIC AlsaLoopSubdevT *ApiLoopFindSubdev(SoftMixerT *mixer, const char *streamU
     return NULL;
 }
 
+STATIC int CheckOneSubdev(SoftMixerT *mixer, AlsaSndLoopT *loop, AlsaLoopSubdevT *subdev) {
+    // create loop subdev entry point with cardidx+device+subdev in order to open subdev and not sndcard
+    AlsaDevInfoT loopSubdev;
+    loopSubdev.devpath=NULL;
+    loopSubdev.cardid=NULL;
+    loopSubdev.pcmplug_params = NULL;
+    loopSubdev.cardidx = loop->sndcard->cid.cardidx;
+    loopSubdev.device = loop->capture;
+    loopSubdev.subdev = subdev->index;
+
+    // assert we may open this loopback subdev in capture mode
+    AlsaPcmCtlT *pcmInfo = AlsaByPathOpenPcm(mixer, &loopSubdev, SND_PCM_STREAM_CAPTURE);
+    if (!pcmInfo)
+      goto OnErrorExit;
+
+    // free PCM as we only open loop to assert it's a valid capture device
+    snd_pcm_close(pcmInfo->handle);
+    free(pcmInfo);
+
+    return 0;
+
+OnErrorExit:
+    AFB_ApiError(mixer->api, "%s: Failed", __func__);
+
+    return -1;
+}
+
+STATIC AlsaLoopSubdevT *ProcessOneAvirtSubdev(SoftMixerT *mixer, AlsaSndLoopT *loop, int index) {
+    AFB_ApiInfo(mixer->api, "%s: %d", __func__, index);
+
+    AlsaLoopSubdevT *subdev = calloc(1, sizeof (AlsaPcmCtlT));
+    subdev->uid = NULL;
+    subdev->index = index;
+    subdev->numid = numidmap[index].index;
+
+    if (CheckOneSubdev(mixer, loop, subdev) < 0)
+      return NULL;
+    
+    return subdev;
+}
+
 STATIC AlsaLoopSubdevT *ProcessOneSubdev(SoftMixerT *mixer, AlsaSndLoopT *loop, json_object *subdevJ) {
     AlsaLoopSubdevT *subdev = calloc(1, sizeof (AlsaPcmCtlT));
 
@@ -63,89 +146,179 @@ STATIC AlsaLoopSubdevT *ProcessOneSubdev(SoftMixerT *mixer, AlsaSndLoopT *loop, 
     // subdev with no UID are dynamically attached
     if (subdev->uid) subdev->uid = strdup(subdev->uid);
 
-    // create loop subdev entry point with cardidx+device+subdev in order to open subdev and not sndcard
-    AlsaDevInfoT loopSubdev;
-    loopSubdev.devpath=NULL;
-    loopSubdev.cardid=NULL;
-    loopSubdev.pcmplug_params = NULL;
-    loopSubdev.cardidx = loop->sndcard->cid.cardidx;
-    loopSubdev.device = loop->capture;
-    loopSubdev.subdev = subdev->index;
-
-    // assert we may open this loopback subdev in capture mode
-    AlsaPcmCtlT *pcmInfo = AlsaByPathOpenPcm(mixer, &loopSubdev, SND_PCM_STREAM_CAPTURE);
-    if (!pcmInfo) goto OnErrorExit;
-
-    // free PCM as we only open loop to assert it's a valid capture device
-    snd_pcm_close(pcmInfo->handle);
-    free(pcmInfo);
-
+    if (CheckOneSubdev(mixer, loop, subdev) < 0)
+      goto OnErrorExit;
+    
     return subdev;
 
 OnErrorExit:
     return NULL;
 }
 
-STATIC AlsaSndLoopT *AttachOneLoop(SoftMixerT *mixer, const char *uid, json_object *argsJ) {
+STATIC int AttachOneAvirtLoop(SoftMixerT *mixer, json_object *streamJ) {
+    char *uid, *zone_uid;
+    int error;
+    AlsaSndZoneT *zone;
+
+    uid = alloca(32);
+
+    error = wrap_json_unpack(streamJ, "{ss,s?s,s?s,ss,s?s,s?i,s?b,s?o,s?s !}"
+            , "uid", &uid
+            , "verb", NULL
+            , "info", NULL
+            , "zone", &zone_uid
+            , "source", NULL
+            , "volume", NULL
+            , "mute", NULL
+            , "params", NULL
+            , "ramp", NULL
+            );
+
+    if (error)
+    {
+        AFB_ApiNotice(mixer->api,
+                       "%s: hal=%s missing 'uid|[info]|zone|source||[volume]|[mute]|[params]' error=%s stream=%s",
+                       __func__, uid, wrap_json_get_error_string(error), json_object_get_string(streamJ));
+        goto OnErrorExit;
+    }
+
+    if (mixer->zones[0]) {
+      zone = ApiZoneGetByUid(mixer, zone_uid);
+    } else {
+      AFB_ApiError(mixer->api, "%s: No zones defined!", __func__);
+      goto OnErrorExit;
+    }
+
+    error = snd_avirt_stream_new(uid, zone->ccount,
+                                 SND_PCM_STREAM_PLAYBACK, "ap_loopback");
+    if (error < 0)
+    {
+      AFB_ApiError(mixer->api,
+      "%s: mixer=%s stream=%s could not create AVIRT stream [errno=%d]",
+      __func__, mixer->uid, uid, error);
+      return error;
+    }
+
+    return 0;
+
+OnErrorExit:
+    AFB_ApiError(mixer->api, "%s fail", __func__);
+    return 0;
+}
+
+STATIC AlsaSndLoopT *AttachOneLoop(SoftMixerT *mixer, const char *uid, json_object *argsJ, json_object *streamsJ) {
     AlsaSndLoopT *loop = calloc(1, sizeof (AlsaSndLoopT));
     json_object *subdevsJ = NULL, *devicesJ = NULL;
-    int error;
+    int error, index;
+
+    AFB_ApiNotice(mixer->api, "%s", __func__);
 
     loop->sndcard = (AlsaSndCtlT*) calloc(1, sizeof (AlsaSndCtlT));
-    error = wrap_json_unpack(argsJ, "{ss,s?s,s?s,so,so !}"
+    error = wrap_json_unpack(argsJ, "{ss,s?s,s?s,s?o,s?o !}"
             , "uid", &loop->uid
             , "path", &loop->sndcard->cid.devpath
             , "cardid", &loop->sndcard->cid.cardid
             , "devices", &devicesJ
             , "subdevs", &subdevsJ
             );
-    if (error || !loop->uid || !subdevsJ || (!loop->sndcard->cid.devpath && !loop->sndcard->cid.cardid)) {
+
+    if (loop->uid) {
+        if (!strcmp(loop->uid, UID_AVIRT_LOOP))
+            loop->avirt = true;
+        else
+            loop->avirt = false;
+    }
+
+    if (error || !loop->uid || (!loop->avirt && !subdevsJ) || (!loop->sndcard->cid.devpath && !loop->sndcard->cid.cardid)) {
         AFB_ApiNotice(mixer->api, "%s mixer=%s hal=%s missing 'uid|path|cardid|devices|subdevs' error=%s args=%s",
         		__func__, mixer->uid, uid, wrap_json_get_error_string(error),json_object_get_string(argsJ));
         goto OnErrorExit;
     }
 
-    // try to open sound card control interface
-    loop->sndcard->ctl = AlsaByPathOpenCtl(mixer, loop->uid, loop->sndcard);
-    if (!loop->sndcard->ctl) {
-        AFB_ApiError(mixer->api, "%s mixer=%s hal=%s Fail open sndcard loop=%s devpath=%s cardid=%s (please check 'modprobe snd_aloop')",
-        		__func__, mixer->uid, uid, loop->uid, loop->sndcard->cid.devpath, loop->sndcard->cid.cardid);
-        goto OnErrorExit;
-    }
+    if (!loop->avirt) {
+        // try to open sound card control interface
+        loop->sndcard->ctl = AlsaByPathOpenCtl(mixer, loop->uid, loop->sndcard);
+        if (!loop->sndcard->ctl) {
+            AFB_ApiError(mixer->api, "%s mixer=%s hal=%s Fail open sndcard loop=%s devpath=%s cardid=%s (please check 'modprobe snd_aloop')",
+                __func__, mixer->uid, uid, loop->uid, loop->sndcard->cid.devpath, loop->sndcard->cid.cardid);
+            goto OnErrorExit;
+      }
 
-    // Default devices is payback=0 capture=1
-    if (!devicesJ) {
-        loop->playback = 0;
-        loop->capture = 1;
-    } else {
-        error = wrap_json_unpack(devicesJ, "{si,si !}", "capture", &loop->capture, "playback", &loop->playback);
-        if (error) {
-            AFB_ApiNotice(mixer->api, "%s mixer=%s hal=%s Loop=%s missing 'capture|playback' error=%s devices=%s",
-            		__func__, mixer->uid, uid, loop->uid, wrap_json_get_error_string(error),json_object_get_string(devicesJ));
+      // Default devices is payback=0 capture=1
+      if (!devicesJ) {
+          loop->playback = 0;
+          loop->capture = 1;
+      } else {
+          error = wrap_json_unpack(devicesJ, "{si,si !}", "capture", &loop->capture, "playback", &loop->playback);
+          if (error) {
+              AFB_ApiNotice(mixer->api, "%s mixer=%s hal=%s Loop=%s missing 'capture|playback' error=%s devices=%s",
+                  __func__, mixer->uid, uid, loop->uid, wrap_json_get_error_string(error),json_object_get_string(devicesJ));
+              goto OnErrorExit;
+          }
+      }
+
+      switch (json_object_get_type(subdevsJ)) {
+          case json_type_object:
+              loop->scount = 1;
+              loop->subdevs = calloc(2, sizeof (void*));
+              loop->subdevs[0] = ProcessOneSubdev(mixer, loop, subdevsJ);
+              if (!loop->subdevs[0]) goto OnErrorExit;
+              break;
+          case json_type_array:
+              loop->scount = (int) json_object_array_length(subdevsJ);
+              loop->subdevs = calloc(loop->scount + 1, sizeof (void*));
+              for (int idx = 0; idx < loop->scount; idx++) {
+                  json_object *subdevJ = json_object_array_get_idx(subdevsJ, idx);
+                  loop->subdevs[idx] = ProcessOneSubdev(mixer, loop, subdevJ);
+                  if (!loop->subdevs[idx]) goto OnErrorExit;
+              }
+              break;
+          default:
+              AFB_ApiError(mixer->api, "%s mixer=%s hal=%s Loop=%s invalid subdevs= %s",
+                  __func__, mixer->uid, uid, loop->uid, json_object_get_string(subdevsJ));
+              goto OnErrorExit;
+      }
+    } else { // loop->avirt == true
+        for (index = 0; index < mixer->max.streams; index++) {
+            if (!mixer->streams[index]) break;
+        }
+
+        if (index == mixer->max.streams)
+            goto OnErrorExit;
+
+        // Create AVIRT streams
+        switch (json_object_get_type(streamsJ)) {
+            case json_type_object:
+                loop->scount = 1;
+                loop->subdevs = calloc(2, sizeof (void*));
+                AttachOneAvirtLoop(mixer, streamsJ);
+                loop->subdevs[0] = ProcessOneAvirtSubdev(mixer, loop, 0);
+                break;
+
+            case json_type_array:
+                loop->scount = json_object_array_length(streamsJ);
+                if (loop->scount > (mixer->max.streams - index))
+                    goto OnErrorExit;
+                loop->subdevs = calloc(loop->scount + 1, sizeof (void*));
+                for (int idx = 0; idx < loop->scount; idx++) {
+                    json_object *streamJ = json_object_array_get_idx(streamsJ, idx);
+                    AttachOneAvirtLoop(mixer, streamJ);
+                    loop->subdevs[idx] = ProcessOneAvirtSubdev(mixer, loop, idx);
+                }
+                break;
+            default:
+                goto OnErrorExit;
+        }
+
+        snd_avirt_card_seal();
+
+        // try to open sound card control interface
+        loop->sndcard->ctl = AlsaByPathOpenCtl(mixer, loop->uid, loop->sndcard);
+        if (!loop->sndcard->ctl) {
+            AFB_ApiError(mixer->api, "%s mixer=%s hal=%s Fail open sndcard loop=%s devpath=%s cardid=%s (please check 'modprobe snd_aloop')",
+                __func__, mixer->uid, uid, loop->uid, loop->sndcard->cid.devpath, loop->sndcard->cid.cardid);
             goto OnErrorExit;
         }
-    }
-
-    switch (json_object_get_type(subdevsJ)) {
-        case json_type_object:
-            loop->scount = 1;
-            loop->subdevs = calloc(2, sizeof (void*));
-            loop->subdevs[0] = ProcessOneSubdev(mixer, loop, subdevsJ);
-            if (!loop->subdevs[0]) goto OnErrorExit;
-            break;
-        case json_type_array:
-            loop->scount = (int) json_object_array_length(subdevsJ);
-            loop->subdevs = calloc(loop->scount + 1, sizeof (void*));
-            for (int idx = 0; idx < loop->scount; idx++) {
-                json_object *subdevJ = json_object_array_get_idx(subdevsJ, idx);
-                loop->subdevs[idx] = ProcessOneSubdev(mixer, loop, subdevJ);
-                if (!loop->subdevs[idx]) goto OnErrorExit;
-            }
-            break;
-        default:
-            AFB_ApiError(mixer->api, "%s mixer=%s hal=%s Loop=%s invalid subdevs= %s",
-            		__func__, mixer->uid, uid, loop->uid, json_object_get_string(subdevsJ));
-            goto OnErrorExit;
     }
 
     // we may have to register up to 3 control per subdevice (vol, pause, actif)
@@ -158,7 +331,7 @@ OnErrorExit:
     return NULL;
 }
 
-PUBLIC int ApiLoopAttach(SoftMixerT *mixer, AFB_ReqT request, const char *uid, json_object * argsJ) {
+PUBLIC int ApiLoopAttach(SoftMixerT *mixer, AFB_ReqT request, const char *uid, json_object * argsJ, json_object *streamsJ) {
 
     int index;
     for (index = 0; index < mixer->max.loops; index++) {
@@ -174,7 +347,7 @@ PUBLIC int ApiLoopAttach(SoftMixerT *mixer, AFB_ReqT request, const char *uid, j
             size_t count;
 
         case json_type_object:
-            mixer->loops[index] = AttachOneLoop(mixer, uid, argsJ);
+            mixer->loops[index] = AttachOneLoop(mixer, uid, argsJ, streamsJ);
             if (!mixer->loops[index]) {
                 goto OnErrorExit;
             }
@@ -190,7 +363,7 @@ PUBLIC int ApiLoopAttach(SoftMixerT *mixer, AFB_ReqT request, const char *uid, j
 
             for (int idx = 0; idx < count; idx++) {
                 json_object *loopJ = json_object_array_get_idx(argsJ, idx);
-                mixer->loops[index + idx] = AttachOneLoop(mixer, uid, loopJ);
+                mixer->loops[index + idx] = AttachOneLoop(mixer, uid, loopJ, streamsJ);
                 if (!mixer->loops[index + idx]) {
                     goto OnErrorExit;
                 }

--- a/plugins/alsa/alsa-api-mixer.c
+++ b/plugins/alsa/alsa-api-mixer.c
@@ -664,8 +664,8 @@ static void MixerBluezAlsaDevVerb(AFB_ReqT request) {
     }
 
 parsed:
-	printf("%s: interface %s, device %s, profile %s\n", __func__, interface, device, profile);
-    error = alsa_bluez_set_device(interface, device, profile);
+	AFB_ApiNotice(mixer->api, "%s: interface %s, device %s, profile %s\n", __func__, interface, device, profile);
+    error = alsa_bluez_set_remote_device(0, interface, device, profile);
     if (error) {
     	AFB_ReqFailF(request,
     	             "runtime error",

--- a/plugins/alsa/alsa-api-streams.c
+++ b/plugins/alsa/alsa-api-streams.c
@@ -201,6 +201,7 @@ STATIC int CreateOneStream(SoftMixerT *mixer, const char * uid, AlsaStreamAudioT
     char *volName = NULL;
     int pauseNumid = 0;
     int volNumid = 0;
+    int device, subdev;
 
     AFB_ApiInfo(mixer->api,
                 "%s, stream %s %s, source %s, sink %s, mute %d",
@@ -208,12 +209,20 @@ STATIC int CreateOneStream(SoftMixerT *mixer, const char * uid, AlsaStreamAudioT
 
     loopDev = ApiLoopFindSubdev(mixer, stream->uid, stream->source, &loop);
     if (loopDev) {
+        if (loop->avirt) {
+            device = loopDev->index;
+            subdev = 0;
+        } else { // loop->avirt == false
+            device = loop->capture;
+            subdev = loopDev->index;
+        }
+
         // create a valid PCM reference and try to open it.
         captureDev->devpath = NULL;
         captureDev->cardid = NULL;
         captureDev->cardidx = loop->sndcard->cid.cardidx;
-        captureDev->device = loop->capture;
-        captureDev->subdev = loopDev->index;
+        captureDev->device = device;
+        captureDev->subdev = subdev;
         captureDev->pcmplug_params = NULL;
         captureCard = loop->sndcard;
 

--- a/plugins/alsa/alsa-api-streams.c
+++ b/plugins/alsa/alsa-api-streams.c
@@ -21,6 +21,8 @@
 #include "alsa-softmixer.h"
 #include "alsa-bluez.h"
 
+#include <avirt/avirt.h>
+
 #include <string.h>
 #include <stdbool.h>
 #include <dlfcn.h>

--- a/plugins/alsa/alsa-ringbuf.c
+++ b/plugins/alsa/alsa-ringbuf.c
@@ -25,7 +25,7 @@ snd_pcm_uframes_t alsa_ringbuf_capacity(const alsa_ringbuf_t *rb) {
 	return ringbuf_capacity(rb->rbuf)/rb->frameSize;
 }
 
-snd_pcm_uframes_t alsa_ringbuf_frames_free(const alsa_ringbuf_t *rb) {
+snd_pcm_uframes_t alsa_ringbuf_frames_remain_capacity(const alsa_ringbuf_t *rb) {
 	return ringbuf_bytes_free(rb->rbuf)/rb->frameSize;
 }
 

--- a/plugins/alsa/alsa-ringbuf.h
+++ b/plugins/alsa/alsa-ringbuf.h
@@ -16,7 +16,7 @@ extern snd_pcm_uframes_t alsa_ringbuf_buffer_size(const alsa_ringbuf_t *rb);
 extern void alsa_ringbuf_free(alsa_ringbuf_t *rb);
 extern void alsa_ringbuf_reset(alsa_ringbuf_t *rb);
 extern snd_pcm_uframes_t alsa_ringbuf_capacity(const alsa_ringbuf_t *rb);
-extern snd_pcm_uframes_t alsa_ringbuf_frames_free(const alsa_ringbuf_t *rb);
+extern snd_pcm_uframes_t alsa_ringbuf_frames_remain_capacity(const alsa_ringbuf_t *rb);
 extern snd_pcm_uframes_t alsa_ringbuf_frames_used(const alsa_ringbuf_t *rb);
 extern bool alsa_ringbuf_is_full(const alsa_ringbuf_t *rb);
 extern bool alsa_ringbuf_is_empty(const alsa_ringbuf_t *rb);

--- a/plugins/alsa/alsa-softmixer.h
+++ b/plugins/alsa/alsa-softmixer.h
@@ -210,17 +210,18 @@ typedef struct {
 
 typedef struct {
     const char*uid;
-    int index;
+    int index; // AVIRT: parent PCM index (Since subdev idx is always 0)
     int numid;
 } AlsaLoopSubdevT;
 
 typedef struct {
+    bool avirt; // AVIRT: Is this loop AVIRT?
     const char *uid;
-    int playback;
-    int capture;
-    long scount;
+    int playback; // AVIRT: UNUSED
+    int capture; // AVIRT: UNUSED
+    long scount; // AVIRT: PCM count
     AlsaSndCtlT *sndcard;
-    AlsaLoopSubdevT **subdevs;
+    AlsaLoopSubdevT **subdevs; // AVIRT: each subdev is on a different PCM
 } AlsaSndLoopT;
 
 typedef struct {
@@ -306,7 +307,7 @@ PUBLIC AlsaPcmCtlT* AlsaCreateDmix(SoftMixerT *mixer, const char* pcmName, AlsaS
 
 // alsa-api-*
 PUBLIC AlsaLoopSubdevT *ApiLoopFindSubdev(SoftMixerT *mixer, const char *streamUid, const char *targetUid, AlsaSndLoopT **loop);
-PUBLIC int ApiLoopAttach(SoftMixerT *mixer, AFB_ReqT request, const char *uid, json_object * argsJ);
+PUBLIC int ApiLoopAttach(SoftMixerT *mixer, AFB_ReqT request, const char *uid, json_object * argsJ, json_object *streamsJ);
 PUBLIC AlsaPcmHwInfoT *ApiPcmSetParams(SoftMixerT *mixer, const char *uid, json_object *paramsJ);
 PUBLIC AlsaSndPcmT *ApiPcmAttachOne(SoftMixerT *mixer, const char *uid, snd_pcm_stream_t direction, json_object *argsJ);
 PUBLIC AlsaVolRampT *ApiRampGetByUid(SoftMixerT *mixer, const char *uid);


### PR DESCRIPTION

Add initial conversion to use AVIRT loopback

- Migrate to use the AVIRT (snd-avirt) loopback driver instead of
  snd-aloop.
- The AVIRT card is dynamically created, and each stream is
  separated into it's own PCM device, unlike snd-aloop.
- Add libavirt. This is a convenience library for interacting with
  AVIRT. Adding streams, sealing the card, and querying PCM info is
  currently supported.
- Add REGNUMID table, for ALSA ctls. Since the loopback is constructed
  dynamically, we need these REGNUMIDs in C.
- Backwards compatible: retain ability to continue using snd-aloop
